### PR TITLE
Update shell script for Implement Load Balancing on Compute Engine

### DIFF
--- a/Implement Load Balancing on Compute Engine Challenge Lab/gsp313.sh
+++ b/Implement Load Balancing on Compute Engine Challenge Lab/gsp313.sh
@@ -43,14 +43,12 @@ EOF
  
 gcloud compute instance-templates create web-server-template \
         --metadata-from-file startup-script=startup.sh \
-        --machine-type g1-small \
-        --region $REGION
+        --machine-type e2-medium \
  
 gcloud compute instance-groups managed create web-server-group \
         --base-instance-name web-server \
         --size 2 \
         --template web-server-template \
-        --region $REGION
  
 gcloud compute firewall-rules create $FIREWALL \
         --allow tcp:80 \
@@ -61,7 +59,6 @@ gcloud compute http-health-checks create http-basic-check
 gcloud compute instance-groups managed \
         set-named-ports web-server-group \
         --named-ports http:80 \
-        --region $REGION
  
 gcloud compute backend-services create web-server-backend \
         --protocol HTTP \
@@ -70,7 +67,6 @@ gcloud compute backend-services create web-server-backend \
  
 gcloud compute backend-services add-backend web-server-backend \
         --instance-group web-server-group \
-        --instance-group-region $REGION \
         --global
  
 gcloud compute url-maps create web-server-map \


### PR DESCRIPTION
Updating the shell script for "Implement Load Balancing on Compute Engine" challenge lab

- The machine type is `e2-medium` and the template needs to be global

*NOTE* : This should fix it but NEEDS TESTING.

Also, I ran into an issue of exhaustion:

<img width="1413" alt="Screenshot 2024-07-30 at 18 15 36" src="https://github.com/user-attachments/assets/c25d5ad2-d1b8-4bb7-902c-b7dbf2772ef2">
<img width="1413" alt="Screenshot 2024-07-30 at 18 15 36" src="https://github.com/user-attachments/assets/daf9a042-e489-4992-887c-d6b2fe1f6faf">

However, the script ran successfully:
<img width="1197" alt="Screenshot 2024-07-30 at 18 15 48" src="https://github.com/user-attachments/assets/99f5b19e-0a0c-43d7-95b9-9438e03828a7">
